### PR TITLE
more tweaks for python v3, plus some suggestions for the future

### DIFF
--- a/obd/obd.py
+++ b/obd/obd.py
@@ -43,16 +43,16 @@ from .debug import debug
 class OBD(object):
 	""" class representing an OBD-II connection with it's assorted sensors """
 
-	def __init__(self, portstr=None):
+	def __init__(self, portstr=None, baudrate=38400):
 		self.port = None
 		self.supported_commands = []
 
 		debug("========================== Starting python-OBD ==========================")
-		self.connect(portstr) # initialize by connecting and loading sensors
+		self.connect(portstr, baudrate) # initialize by connecting and loading sensors
 		debug("=========================================================================")
 
 
-	def connect(self, portstr=None):
+	def connect(self, portstr=None, baudrate=38400):
 		""" attempts to instantiate an ELM327 object. Loads commands on success"""
 
 		if portstr is None:
@@ -61,15 +61,15 @@ class OBD(object):
 			debug("Available ports: " + str(portnames))
 
 			for port in portnames:
-
-				self.port = ELM327(port)
+				debug("Attempting to use port: " + str(port))
+				self.port = ELM327(port, baudrate=baudrate)
 
 				if self.port.is_connected():
 					# success! stop searching for serial
 					break
 		else:
 			debug("Explicit port defined")
-			self.port = ELM327(portstr)
+			self.port = ELM327(portstr, baudrate=baudrate)
 
 		# if a connection was made, query for commands
 		if self.is_connected():


### PR DESCRIPTION
ELM327 only

I overcame the Py3 problems against obdsim with some minor changes to the __read and __write methods. I also made baudrate configurable in this class to use as a starting point for making it configurable elsewhere (my reader isn't operating at 38.4, so I need this), and changed the checks for "OK" to use a common function rather than repeating similar code over and over. 

I strongly recommend changing __read to return a list of sanitized strings (like the way my __isok method does) rather than relying on your current strip method (I think the strip method is contributing to issue #13). I think it will make interpreting the data a lot easier later on.